### PR TITLE
Improve GPU detection scripts handling for missing deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Each script will display the following information:
 
 ## Requirements
 
-Ensure you have the necessary libraries installed:
+Ensure you have the necessary libraries installed. The scripts will notify you
+if either library is missing:
 
 ```bash
 pip install torch tensorflow

--- a/gpu_test.py
+++ b/gpu_test.py
@@ -1,14 +1,30 @@
 # gpu_test.py
-import torch
-import tensorflow as tf
+try:
+    import torch
+except ModuleNotFoundError:
+    torch = None
+    print("PyTorch is not installed.")
+
+try:
+    import tensorflow as tf
+except ModuleNotFoundError:
+    tf = None
+    print("TensorFlow is not installed.")
 
 # Check PyTorch GPU
 print("PyTorch:")
-print(f"CUDA available: {torch.cuda.is_available()}")
-print(f"CUDA device count: {torch.cuda.device_count()}")
-if torch.cuda.is_available():
-    print(f"CUDA device name: {torch.cuda.get_device_name(0)}")
+if torch is None:
+    print("PyTorch not available.")
+else:
+    print(f"CUDA available: {torch.cuda.is_available()}")
+    print(f"CUDA device count: {torch.cuda.device_count()}")
+    if torch.cuda.is_available() and torch.cuda.device_count() > 0:
+        print(f"CUDA device name: {torch.cuda.get_device_name(0)}")
 
 # Check TensorFlow GPU
 print("\nTensorFlow:")
-print(f"Num GPUs Available: {len(tf.config.experimental.list_physical_devices('GPU'))}")
+if tf is None:
+    print("TensorFlow not available.")
+else:
+    num_gpus = len(tf.config.experimental.list_physical_devices('GPU'))
+    print(f"Num GPUs Available: {num_gpus}")

--- a/gpu_test_pytorch.py
+++ b/gpu_test_pytorch.py
@@ -1,7 +1,14 @@
 # gpu_test_pytorch.py
-import torch
+try:
+    import torch
+except ModuleNotFoundError:
+    torch = None
+    print("PyTorch is not installed.")
 
-print("CUDA available: ", torch.cuda.is_available())
-print("CUDA device count: ", torch.cuda.device_count())
-if torch.cuda.is_available():
-    print("CUDA device name: ", torch.cuda.get_device_name(0))
+if torch is None:
+    print("PyTorch not available.")
+else:
+    print("CUDA available: ", torch.cuda.is_available())
+    print("CUDA device count: ", torch.cuda.device_count())
+    if torch.cuda.is_available() and torch.cuda.device_count() > 0:
+        print("CUDA device name: ", torch.cuda.get_device_name(0))

--- a/gpu_test_tf.py
+++ b/gpu_test_tf.py
@@ -1,4 +1,12 @@
 # gpu_test_tf.py
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ModuleNotFoundError:
+    tf = None
+    print("TensorFlow is not installed.")
 
-print("Num GPUs Available: ", len(tf.config.experimental.list_physical_devices('GPU')))
+if tf is None:
+    print("TensorFlow not available.")
+else:
+    num_gpus = len(tf.config.experimental.list_physical_devices('GPU'))
+    print("Num GPUs Available: ", num_gpus)


### PR DESCRIPTION
## Summary
- gracefully handle missing PyTorch or TensorFlow in all scripts
- note missing library behaviour in the README

## Testing
- `python -m py_compile gpu_test.py gpu_test_pytorch.py gpu_test_tf.py`
- `python gpu_test.py`
- `python gpu_test_pytorch.py`
- `python gpu_test_tf.py`


------
https://chatgpt.com/codex/tasks/task_e_683fad57f1bc8321aff90cca866814b1